### PR TITLE
Faster move to next post

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A browser extension for adding shortcuts to bsky.app.
 4. Visit the [chrome extensions page](chrome://extensions/)
     1. (or enter `chrome://extensions/` in the Chrome address bar)
 5. Enable `Developer mode` in the top right
-6. Click `Load unpacked` in the top left and select the `bsky-shortcuts/build` folder
+6. Click `Load unpacked` in the top left and select the `bsky-shortcuts/build/chrome` folder
 
 ## Contributing
 

--- a/src/content-scripts/dom-utils.js
+++ b/src/content-scripts/dom-utils.js
@@ -63,6 +63,13 @@ export default class DOMUtils {
         });
     }
 
+    /**
+     * Safely scroll into view
+     * @param {Element} element - The element to scroll into view
+     * @param {Object} options - The options for the scroll
+     * @param {boolean} options.skipScroll - Whether to skip the scroll
+     * @param {"smooth"|"instant"|"auto"} options.behavior - The behavior of the scroll. See [here](https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo#behavior) for more information.
+     */
     static safelyScrollIntoView(element, options = {}) {
         if (!element) return;
 

--- a/src/content-scripts/main.js
+++ b/src/content-scripts/main.js
@@ -258,7 +258,7 @@ class BlueSkyShortcuts {
 
         this.resetFocus();
         this.appState.updateState({ currentPost: nextPost, currentLinkIndex: -1 });
-        DOMUtils.safelyScrollIntoView(nextPost);
+        DOMUtils.safelyScrollIntoView(nextPost, { behavior: 'instant' });
 
         if (nextPost) {
             nextPost.tabIndex = 0;
@@ -291,7 +291,7 @@ class BlueSkyShortcuts {
 
         this.resetFocus();
         this.appState.updateState({ currentPost: prevPost, currentLinkIndex: -1 });
-        DOMUtils.safelyScrollIntoView(prevPost);
+        DOMUtils.safelyScrollIntoView(prevPost, { behavior: 'instant' });
 
         if (prevPost) {
             prevPost.tabIndex = 0;


### PR DESCRIPTION
Related to [this feature request](https://github.com/mattburesh/bluesky-shortcuts/issues/52). 

**Changes**

* Move instantly to next/prev post with `j/k`
* Add JSDocs
* Improve README

Let me know if you'd like me to split the README/JSDoc changes into separate PRs.