### PR TITLE
change loadPostsButton's selector

### DIFF
--- a/src/content-scripts/main.js
+++ b/src/content-scripts/main.js
@@ -637,7 +637,7 @@ class BlueSkyShortcuts {
     }
 
     async loadMore() {
-        const loadPostsButton = document.querySelector('[aria-label*="Load new posts"]') ?? null;
+        const loadPostsButton = document.querySelector( 'div[data-testid="loadLatestBtn"] button') ?? null;
 
         if (loadPostsButton) {
             this.appState.updateState({ currentPost: null });


### PR DESCRIPTION
The aria-label attribute of the loadPostsButton varies depending on the language.
In Japanese, it is "最新の投稿を読み込む".

So, I changed loadPostsButton's selector.
