### PR TITLE
Add DOM matching for posts in search and hashtag views

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bluesky-shortcuts",
-    "version": "1.6.3",
+    "version": "1.7.0",
     "description": "Adds keyboard shortcuts to bsky.app",
     "scripts": {
         "build": "npm run build:chrome:prod && npm run build:firefox:prod",

--- a/src/content-scripts/dom-utils.js
+++ b/src/content-scripts/dom-utils.js
@@ -43,7 +43,7 @@ export default class DOMUtils {
 
     static findVisiblePosts() {
         var searchResults = []
-        if (document.title === "Hashtag — Bluesky" || document.title === "Explore — Bluesky") {
+        if ([/Hashtag — Bluesky$/, /Explore — Bluesky$/].some(pattern => pattern.test(document.title))) {
             // This selector matches all posts in search lists, but can throw
             // false positives in other views like threads
             const searchQuery = 'div:not([style]) > div[role="link"][tabindex]:not([aria-label*="Reposted by"])'

--- a/src/content-scripts/dom-utils.js
+++ b/src/content-scripts/dom-utils.js
@@ -41,15 +41,21 @@ export default class DOMUtils {
         return attempt();
     }
 
-    /**
-     * Todo: Add search results feed
-     */
     static findVisiblePosts() {
+        var searchResults = []
+        if (document.title === "Hashtag — Bluesky" || document.title === "Explore — Bluesky") {
+            // This selector matches all posts in search lists, but can throw
+            // false positives in other views like threads
+            const searchQuery = 'div:not([style]) > div[role="link"][tabindex]:not([aria-label*="Reposted by"])'
+            searchResults = document.querySelectorAll(searchQuery)
+        }
         const feedItems = [
             // Main feed items
             ...document.querySelectorAll('div[data-testid*="feedItem-by-"]'),
             // Thread/reply items
-            ...document.querySelectorAll('div[data-testid*="postThreadItem-by-"]')
+            ...document.querySelectorAll('div[data-testid*="postThreadItem-by-"]'),
+            // Search results
+            ...searchResults
         ].filter(el => el.offsetParent !== null);
 
         return feedItems;


### PR DESCRIPTION
Fixes #5. 

Unfortunately this cannot be done with querySelector alone, but it is possible to match posts in the search views by running this selector conditionally depending on the view. 